### PR TITLE
Potential fix for code scanning alert no. 3: Potentially unsafe quoting

### DIFF
--- a/internal/tools/a2a_dispatch.go
+++ b/internal/tools/a2a_dispatch.go
@@ -63,21 +63,28 @@ func (t *A2ADispatchTool) Parameters() json.RawMessage {
 		agentDesc += fmt.Sprintf("  - %s (%s)\n", a.Name, a.URL)
 	}
 
-	return json.RawMessage(fmt.Sprintf(`{
+	schema := map[string]any{
 		"type": "object",
-		"properties": {
-			"agent_name": {
-				"type": "string",
-				"description": %q,
-				"enum": %s
+		"properties": map[string]any{
+			"agent_name": map[string]any{
+				"type":        "string",
+				"description": agentDesc,
+				"enum":        agentNames,
 			},
-			"message": {
-				"type": "string",
-				"description": "The task message to send to the agent"
-			}
+			"message": map[string]any{
+				"type":        "string",
+				"description": "The task message to send to the agent",
+			},
 		},
-		"required": ["agent_name", "message"]
-	}`, agentDesc, mustMarshalJSON(agentNames)))
+		"required": []string{"agent_name", "message"},
+	}
+
+	data, err := json.Marshal(schema)
+	if err != nil {
+		return json.RawMessage(`{}`)
+	}
+
+	return json.RawMessage(data)
 }
 
 func (t *A2ADispatchTool) Execute(ctx context.Context, params map[string]any) (ToolResult, error) {
@@ -99,7 +106,4 @@ func (t *A2ADispatchTool) Execute(ctx context.Context, params map[string]any) (T
 	return NewTextToolResult(result), nil
 }
 
-func mustMarshalJSON(v any) string {
-	data, _ := json.Marshal(v)
-	return string(data)
-}
+


### PR DESCRIPTION
Potential fix for [https://github.com/startvibecoding/mothx/security/code-scanning/3](https://github.com/startvibecoding/mothx/security/code-scanning/3)

Build the parameters schema as a structured Go map/object and marshal it to JSON, instead of composing JSON text with `fmt.Sprintf` and embedding `%s`/`%q`.

Best single fix in `internal/tools/a2a_dispatch.go`:
- In `Parameters()`, replace the `fmt.Sprintf`-based `json.RawMessage(...)` return with construction of a `map[string]any` (or equivalent nested maps/slices) representing the same schema.
- Marshal that map with `json.Marshal`.
- Return `json.RawMessage(data)`.
- Keep fallback behavior safe if marshal fails (e.g., return `{}` as raw message).
- This preserves functionality while removing manual quoting risks and satisfying the CodeQL concern.
- After this change, `mustMarshalJSON` is no longer needed and should be removed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
