### PR TITLE
  fix: complete Responses streams and safely rotate bound sessions

### DIFF
--- a/internal/provider/openai/provider_test.go
+++ b/internal/provider/openai/provider_test.go
@@ -10,6 +10,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/startvibecoding/mothx/internal/config"
 	"github.com/startvibecoding/mothx/internal/provider"
@@ -57,6 +58,28 @@ func (b *errorAfterBody) Read(p []byte) (int, error) {
 }
 
 func (b *errorAfterBody) Close() error { return nil }
+
+type blockingAfterBody struct {
+	reader *strings.Reader
+	closed chan struct{}
+}
+
+func (b *blockingAfterBody) Read(p []byte) (int, error) {
+	if b.reader.Len() > 0 {
+		return b.reader.Read(p)
+	}
+	<-b.closed
+	return 0, io.EOF
+}
+
+func (b *blockingAfterBody) Close() error {
+	select {
+	case <-b.closed:
+	default:
+		close(b.closed)
+	}
+	return nil
+}
 
 func newMockOpenAIProvider(t *testing.T, models []*provider.Model, sse string, bodyCh chan<- string, check func(*http.Request)) *Provider {
 	t.Helper()
@@ -1396,6 +1419,62 @@ func TestOpenAIResponsesAPIStreamFailure(t *testing.T) {
 		}
 	}
 	t.Fatal("missing StreamError event")
+}
+
+func TestOpenAIResponsesAPICompletesOnResponseCompletedWithoutDone(t *testing.T) {
+	sse := "data: {\"type\":\"response.output_text.delta\",\"delta\":\"OK\"}\n" +
+		"data: {\"type\":\"response.completed\",\"response\":{\"status\":\"completed\",\"usage\":{\"input_tokens\":1,\"output_tokens\":1,\"total_tokens\":2}}}\n"
+	body := &blockingAfterBody{reader: strings.NewReader(sse), closed: make(chan struct{})}
+	p := NewProviderWithModels("fake-key", "https://api.test/v1", []*provider.Model{{ID: "mock"}})
+	p.SetUseResponsesAPI(true)
+	p.client = &http.Client{Transport: roundTripFunc(func(r *http.Request) (*http.Response, error) {
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       body,
+			Request:    r,
+		}, nil
+	})}
+
+	done := make(chan []provider.StreamEvent, 1)
+	go func() {
+		done <- chatAndCollect(t, p, provider.ChatParams{
+			ModelID:  "mock",
+			Messages: []provider.Message{provider.NewUserMessage("hi")},
+			Abort:    make(chan struct{}),
+		})
+	}()
+
+	var events []provider.StreamEvent
+	select {
+	case events = <-done:
+	case <-time.After(time.Second):
+		body.Close()
+		t.Fatal("stream did not finish after response.completed")
+	}
+
+	var sawText, sawUsage, sawDone bool
+	for _, event := range events {
+		switch event.Type {
+		case provider.StreamTextDelta:
+			sawText = sawText || event.TextDelta == "OK"
+		case provider.StreamUsage:
+			sawUsage = event.Usage != nil && event.Usage.TotalTokens == 2
+		case provider.StreamDone:
+			sawDone = event.StopReason == "stop"
+		case provider.StreamError:
+			t.Fatalf("unexpected StreamError: %v", event.Error)
+		}
+	}
+	if !sawText {
+		t.Fatal("missing text delta")
+	}
+	if !sawUsage {
+		t.Fatal("missing usage")
+	}
+	if !sawDone {
+		t.Fatal("missing StreamDone with stop reason")
+	}
 }
 
 func TestOpenAIResponsesFactoryEnablesResponsesMode(t *testing.T) {

--- a/internal/provider/openai/responses.go
+++ b/internal/provider/openai/responses.go
@@ -352,6 +352,7 @@ func (p *Provider) parseResponsesSSE(ctx context.Context, body io.Reader, ch cha
 		toolCallOrder   []string
 		argumentBuffers = make(map[string]*strings.Builder)
 		visibleOutput   bool
+		completed       bool
 	)
 
 	ch <- provider.StreamEvent{Type: provider.StreamStart}
@@ -368,6 +369,7 @@ func (p *Provider) parseResponsesSSE(ctx context.Context, body io.Reader, ch cha
 		})
 	}()
 
+responsesLoop:
 	for scanner.Scan() {
 		select {
 		case <-ctx.Done():
@@ -434,6 +436,7 @@ func (p *Provider) parseResponsesSSE(ctx context.Context, body io.Reader, ch cha
 				toolCallsByKey[key] = tc
 			}
 		case "response.completed":
+			completed = true
 			if event.Response != nil {
 				usage = convertResponsesUsage(event.Response.Usage)
 				stopReason = responseStopReason(event.Response.Status)
@@ -442,6 +445,10 @@ func (p *Provider) parseResponsesSSE(ctx context.Context, body io.Reader, ch cha
 					return true, nil
 				}
 			}
+			// response.completed is the terminal Responses API event. Some
+			// OpenAI-compatible servers keep the HTTP connection open and omit
+			// the legacy [DONE] sentinel, so do not wait for scanner EOF here.
+			break responsesLoop
 		case "response.failed", "error":
 			if event.Error != nil {
 				ch <- provider.StreamEvent{Type: provider.StreamError, Error: fmt.Errorf("responses error: %s", event.Error.Message), StopReason: "error"}
@@ -468,6 +475,9 @@ func (p *Provider) parseResponsesSSE(ctx context.Context, body io.Reader, ch cha
 	}
 	if stopReason == "" && len(toolCallOrder) > 0 {
 		stopReason = "tool_calls"
+	}
+	if completed && stopReason == "" {
+		stopReason = "stop"
 	}
 	ch <- provider.StreamEvent{Type: provider.StreamDone, StopReason: stopReason}
 	return visibleOutput, nil

--- a/internal/session/bindings.go
+++ b/internal/session/bindings.go
@@ -273,11 +273,11 @@ func RotateBoundSession(workDir, sessionDir, channelType, channelID, oldSessionI
 		return nil, fmt.Errorf("session is no longer bound to %s/%s", channelType, channelID)
 	}
 	id := GenerateID()
-	if _, err := tx.Exec(`INSERT INTO sessions(id, cwd, timestamp, parent_session, version, channel_type, channel_id) VALUES (?, ?, ?, '', ?, ?, ?)`, id, workDir, time.Now().UTC().Format(time.RFC3339Nano), CurrentVersion, channelType, channelID); err != nil {
-		return nil, fmt.Errorf("create rotated session: %w", err)
-	}
 	if _, err := tx.Exec(`UPDATE sessions SET channel_type = 'local', channel_id = '' WHERE id = ?`, oldSessionID); err != nil {
 		return nil, err
+	}
+	if _, err := tx.Exec(`INSERT INTO sessions(id, cwd, timestamp, parent_session, version, channel_type, channel_id) VALUES (?, ?, ?, '', ?, ?, ?)`, id, workDir, time.Now().UTC().Format(time.RFC3339Nano), CurrentVersion, channelType, channelID); err != nil {
+		return nil, fmt.Errorf("create rotated session: %w", err)
 	}
 	if err := tx.Commit(); err != nil {
 		return nil, err

--- a/internal/session/bindings_test.go
+++ b/internal/session/bindings_test.go
@@ -1,0 +1,43 @@
+package session
+
+import "testing"
+
+func TestRotateBoundSessionRebindsChannel(t *testing.T) {
+	sessionDir := t.TempDir()
+	const (
+		workDir     = "/tmp/rotate-bound-session"
+		channelType = "wechat"
+		channelID   = "user-123"
+	)
+
+	old, err := CreateBound(workDir, sessionDir, channelType, channelID)
+	if err != nil {
+		t.Fatalf("create bound session: %v", err)
+	}
+	oldID := old.GetHeader().ID
+
+	rotated, err := RotateBoundSession(workDir, sessionDir, channelType, channelID, oldID)
+	if err != nil {
+		t.Fatalf("rotate bound session: %v", err)
+	}
+	newID := rotated.GetHeader().ID
+	if newID == oldID {
+		t.Fatalf("rotated session reused old ID %q", oldID)
+	}
+
+	binding, err := FindBinding(sessionDir, channelType, channelID)
+	if err != nil {
+		t.Fatalf("find rotated binding: %v", err)
+	}
+	if binding == nil || binding.SessionID != newID {
+		t.Fatalf("binding = %#v, want session %q", binding, newID)
+	}
+
+	oldBinding, err := FindBindingBySessionID(sessionDir, oldID)
+	if err != nil {
+		t.Fatalf("find old session binding: %v", err)
+	}
+	if oldBinding != nil {
+		t.Fatalf("old binding = %#v, want no external binding", oldBinding)
+	}
+}


### PR DESCRIPTION
 ## Summary

  - Safely rotate bound sessions without losing channel replies.
  - Complete OpenAI Responses streams when `response.completed` is received.
  - Add regression tests for both fixes.

  ## Testing

  - `go test -count=1 ./internal/provider/openai`